### PR TITLE
Workspace dependencies not referenceable. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [workspace]
 members = [
-    "components/evm-price-oracle",
-    "components/cosmic-wavs-demo-infusion",
+  "components/evm-price-oracle",
+  "components/cosmic-wavs-demo-infusion",
+  "script/cw-orch-wavs",
+
 ]
 resolver = "2"
 
@@ -15,7 +17,7 @@ rust-version = "1.80.0"
 
 [workspace.dependencies]
 # WASI
-wit-bindgen-rt ={ version = "0.42.1", features = ["bitflags"]}
+wit-bindgen-rt = { version = "0.42.1", features = ["bitflags"] }
 wit-bindgen = "0.42.1"
 wstd = "0.5.3"
 wasi = "0.14.1"
@@ -27,7 +29,7 @@ serde_json = "1.0.140"
 anyhow = "1.0.98"
 
 ## Alloy
-alloy-sol-macro = { version = "1.0.0", features = ["json"]}
+alloy-sol-macro = { version = "1.0.0", features = ["json"] }
 alloy-sol-types = "1.0.0"
 
 
@@ -38,10 +40,11 @@ commonware-codec = "0.0.52"
 
 # Cosmos
 layer-climb = "0.4.3"
-cosmos-sdk-proto = {version = "0.27.0",features = ["cosmwasm"]}
+cosmos-sdk-proto = { version = "0.27.0", features = ["cosmwasm"] }
 cosmwasm-std = { version = "2.2.2", features = [
   "cosmwasm_1_4",
   # Enable this if you only deploy to chains that have CosmWasm 2.0 or higher
   # "cosmwasm_2_0",
 ] }
-
+cosmrs = { version = "2.2.2" }
+cosmwasm-schema = { version = "2.2.2" }


### PR DESCRIPTION
Fixed:
```
error: failed to parse manifest at `/home/poroburu/dev/wavs/cosmic-wavs/script/cw-orch-wavs/Cargo.toml`

Caused by:
  error inheriting `cosmrs` from workspace root manifest's `workspace.dependencies.cosmrs`

Caused by:
  `dependency.cosmrs` was not found in `workspace.dependencies`
```

Current issue:
```
error: no matching package named `btsg-cw-orch` found
location searched: Git repository https://github.com/permissionlessweb/bs-nfts?branch=feat%2Fwavs
required by package `btsg-account-scripts v0.2.0 (https://github.com/permissionlessweb/bs-accounts?branch=cleanup#27cc7342)`
    ... which satisfies git dependency `btsg-account-scripts` of package `cw-orch-wavs v0.1.0 (/home/poroburu/dev/wavs/cosmic-wavs/script/cw-orch-wavs)`
```